### PR TITLE
new feature: change the default way for remove source branch when merged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,23 @@ crashlytics-build.properties
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+### Gradle template
+.gradle
+/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+# gradle/wrapper/gradle-wrapper.properties
+
+.gradle/
+Would
+remove build/idea-sandbox/system/log/
+build/

--- a/src/main/java/com/ppolivka/gitlabprojects/configuration/SettingsState.java
+++ b/src/main/java/com/ppolivka/gitlabprojects/configuration/SettingsState.java
@@ -33,6 +33,8 @@ public class SettingsState implements PersistentStateComponent<SettingsState> {
 
     public String token;
 
+    public boolean defaultRemoveBranch;
+
     public Collection<ProjectDto> projects = new ArrayList<>();
 
     public static SettingsState getInstance() {
@@ -93,6 +95,14 @@ public class SettingsState implements PersistentStateComponent<SettingsState> {
 
     public void setToken(String token) {
         this.token = token;
+    }
+
+    public boolean isDefaultRemoveBranch() {
+        return defaultRemoveBranch;
+    }
+
+    public void setDefaultRemoveBranch(boolean defaultRemoveBranch) {
+        this.defaultRemoveBranch = defaultRemoveBranch;
     }
 
     public Collection<ProjectDto> getProjects() {

--- a/src/main/java/com/ppolivka/gitlabprojects/configuration/SettingsView.form
+++ b/src/main/java/com/ppolivka/gitlabprojects/configuration/SettingsView.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.ppolivka.gitlabprojects.configuration.SettingsView">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="5" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="8" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="751" height="237"/>
@@ -54,7 +54,28 @@
       </component>
       <vspacer id="d9236">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <component id="17d00" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Default Remove Source Branch when merged"/>
+        </properties>
+      </component>
+      <component id="fc9f5" class="javax.swing.JCheckBox" binding="defaultRemoveBranch">
+        <constraints>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Default Remove Source Branch when merged"/>
+        </properties>
+      </component>
+      <vspacer id="2c2c8">
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
     </children>

--- a/src/main/java/com/ppolivka/gitlabprojects/configuration/SettingsView.java
+++ b/src/main/java/com/ppolivka/gitlabprojects/configuration/SettingsView.java
@@ -41,6 +41,7 @@ public class SettingsView implements SearchableConfigurable {
     private JTextField textHost;
     private JTextField textAPI;
     private JButton apiHelpButton;
+    private JCheckBox defaultRemoveBranch;
 
     public void setup() {
         onServerChange();
@@ -139,7 +140,8 @@ public class SettingsView implements SearchableConfigurable {
         String[] save = save();
         return save == null
                 || !save[0].equals(settingsState.getHost())
-                || !save[1].equals(settingsState.getToken());
+                || !save[1].equals(settingsState.getToken())
+                || defaultRemoveBranch.isSelected() != settingsState.isDefaultRemoveBranch();
     }
 
     @Override
@@ -147,6 +149,7 @@ public class SettingsView implements SearchableConfigurable {
         String[] save = save();
         settingsState.setHost(save[0]);
         settingsState.setToken(save[1]);
+        settingsState.setDefaultRemoveBranch(defaultRemoveBranch.isSelected());
     }
 
     @Override
@@ -164,6 +167,7 @@ public class SettingsView implements SearchableConfigurable {
     public void fill(SettingsState settingsState) {
         textHost.setText(settingsState == null ? "" : settingsState.getHost());
         textAPI.setText(settingsState == null ? "" : settingsState.getToken());
+        defaultRemoveBranch.setSelected(settingsState == null ? true : settingsState.isDefaultRemoveBranch());
     }
 
     public String[] save() {

--- a/src/main/java/com/ppolivka/gitlabprojects/merge/list/CodeReviewDialog.form
+++ b/src/main/java/com/ppolivka/gitlabprojects/merge/list/CodeReviewDialog.form
@@ -108,7 +108,7 @@
           <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <selected value="true"/>
+          <selected value="false"/>
           <text value="Remove Source Branch"/>
         </properties>
       </component>

--- a/src/main/java/com/ppolivka/gitlabprojects/merge/list/CodeReviewDialog.java
+++ b/src/main/java/com/ppolivka/gitlabprojects/merge/list/CodeReviewDialog.java
@@ -43,6 +43,8 @@ public class CodeReviewDialog extends DialogWrapper {
     private JLabel assigneeName;
     private JButton assignMe;
 
+    SettingsState settingsState = SettingsState.getInstance();
+
     private boolean diffClicked = false;
 
     protected CodeReviewDialog(@Nullable Project project,
@@ -68,6 +70,8 @@ public class CodeReviewDialog extends DialogWrapper {
         targetBranch = createBranchInfo(mergeRequest.getTargetBranch());
 
         requestName.setText(mergeRequest.getTitle());
+
+        removeSourceBranchCheckBox.setSelected(settingsState.isDefaultRemoveBranch());
 
         String assignee = "";
         if (mergeRequest.getAssignee() != null) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.ppolivka.gitlabprojects</id>
     <name>GitLab Projects</name>
-    <version>1.4.10</version>
+    <version>1.4.11</version>
     <vendor email="polivka.pavel@gmail.com" url="http://ppolivka.com">Pavel Polivka</vendor>
 
     <description><![CDATA[
@@ -17,9 +17,7 @@
     ]]></description>
 
     <change-notes><![CDATA[
-        Adding assignee info to list of merge requests. <br>
-        Adding assignee info to code review dialog. <br>
-        Adding option to assign merge request to me to code review dialog. <br>
+        Adding a feature to disable the default remove branch when merged (author: pdesmet)
     ]]>
     </change-notes>
 


### PR DESCRIPTION
when using gitflow and when merging from develop to master you never want to delete the source branch (develop) so I added a checkbox to disable the default way (not checked by default) 